### PR TITLE
Remove redundant pkg-config cgo directives

### DIFF
--- a/imagick/affine_matrix.go
+++ b/imagick/affine_matrix.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/align_type.go
+++ b/imagick/align_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/alpha_channel_type.go
+++ b/imagick/alpha_channel_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/channel_features.go
+++ b/imagick/channel_features.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickCore
 #include <magick/MagickCore.h>
 */
 import "C"

--- a/imagick/channel_statistics.go
+++ b/imagick/channel_statistics.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickCore
 #include <magick/MagickCore.h>
 */
 import "C"

--- a/imagick/channel_type.go
+++ b/imagick/channel_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/clip_path_units.go
+++ b/imagick/clip_path_units.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/colorspace_type.go
+++ b/imagick/colorspace_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/composite_operator.go
+++ b/imagick/composite_operator.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/compression_type.go
+++ b/imagick/compression_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/conversions.go
+++ b/imagick/conversions.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/decoration_type.go
+++ b/imagick/decoration_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/dispose_type.go
+++ b/imagick/dispose_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/distort_image_method.go
+++ b/imagick/distort_image_method.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/dither_method.go
+++ b/imagick/dither_method.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/draw_info.go
+++ b/imagick/draw_info.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/drawing_wand.go
+++ b/imagick/drawing_wand.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/drawing_wand_exception.go
+++ b/imagick/drawing_wand_exception.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/endian_type.go
+++ b/imagick/endian_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/evaluate_operator.go
+++ b/imagick/evaluate_operator.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/exception_type.go
+++ b/imagick/exception_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/fill_rule.go
+++ b/imagick/fill_rule.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/filter_type.go
+++ b/imagick/filter_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/gravity_type.go
+++ b/imagick/gravity_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/image.go
+++ b/imagick/image.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickCore
 #include <magick/MagickCore.h>
 */
 import "C"

--- a/imagick/image_info.go
+++ b/imagick/image_info.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickCore
 #include <magick/MagickCore.h>
 */
 import "C"

--- a/imagick/image_layer_method.go
+++ b/imagick/image_layer_method.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/image_type.go
+++ b/imagick/image_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/index_packet.go
+++ b/imagick/index_packet.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickCore
 #include <magick/MagickCore.h>
 */
 import "C"

--- a/imagick/interlace_type.go
+++ b/imagick/interlace_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/interpolate_pixel_method.go
+++ b/imagick/interpolate_pixel_method.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/kernel_info.go
+++ b/imagick/kernel_info.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickCore
 #include <magick/MagickCore.h>
 */
 import "C"

--- a/imagick/line_cap.go
+++ b/imagick/line_cap.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/line_join.go
+++ b/imagick/line_join.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/magick_core_env.go
+++ b/imagick/magick_core_env.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/magick_function.go
+++ b/imagick/magick_function.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/magick_pixel_packet.go
+++ b/imagick/magick_pixel_packet.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickCore
 #include <magick/MagickCore.h>
 */
 import "C"

--- a/imagick/magick_version.go
+++ b/imagick/magick_version.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/magick_wand.go
+++ b/imagick/magick_wand.go
@@ -5,7 +5,8 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
+
+#cgo pkg-config: MagickWand MagickCore
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/magick_wand_env.go
+++ b/imagick/magick_wand_env.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/magick_wand_exception.go
+++ b/imagick/magick_wand_exception.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/magick_wand_image.go
+++ b/imagick/magick_wand_image.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/magick_wand_prop.go
+++ b/imagick/magick_wand_prop.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/metric_type.go
+++ b/imagick/metric_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/montage_mode.go
+++ b/imagick/montage_mode.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/morphology_method.go
+++ b/imagick/morphology_method.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/noise_type.go
+++ b/imagick/noise_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/orientation_type.go
+++ b/imagick/orientation_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/paint_method.go
+++ b/imagick/paint_method.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/pixel_iterator.go
+++ b/imagick/pixel_iterator.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 
 static PixelWand* get_pw_at(PixelWand** pws, size_t pos) {

--- a/imagick/pixel_iterator_exception.go
+++ b/imagick/pixel_iterator_exception.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/pixel_packet.go
+++ b/imagick/pixel_packet.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickCore
 #include <magick/MagickCore.h>
 */
 import "C"

--- a/imagick/pixel_wand.go
+++ b/imagick/pixel_wand.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/pixel_wand_exception.go
+++ b/imagick/pixel_wand_exception.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/point_info.go
+++ b/imagick/point_info.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/preview_type.go
+++ b/imagick/preview_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/quantum.go
+++ b/imagick/quantum.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickCore
 #include <magick/MagickCore.h>
 */
 import "C"

--- a/imagick/rectangle_info.go
+++ b/imagick/rectangle_info.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickCore
 #include <magick/MagickCore.h>
 */
 import "C"

--- a/imagick/rendering_intent.go
+++ b/imagick/rendering_intent.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/resolution_type.go
+++ b/imagick/resolution_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/resource_type.go
+++ b/imagick/resource_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/sparse_color_method.go
+++ b/imagick/sparse_color_method.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/statistic_type.go
+++ b/imagick/statistic_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/storage_type.go
+++ b/imagick/storage_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/stretch_type.go
+++ b/imagick/stretch_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/style_type.go
+++ b/imagick/style_type.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"

--- a/imagick/virtual_pixel_method.go
+++ b/imagick/virtual_pixel_method.go
@@ -5,7 +5,6 @@
 package imagick
 
 /*
-#cgo pkg-config: MagickWand
 #include <wand/MagickWand.h>
 */
 import "C"


### PR DESCRIPTION
This is just a "cleanup" commit, to remove all of the redundant pkg-config cgo directives from all but the main `magic_wand.go`, so that the verbose compile output doesn't show 50+ repeated `MagickWand` libs
