### PR TITLE
Fixes #6 - Handling panic when passing empty slice to ReadImageBlob()

### DIFF
--- a/imagick/magick_wand_image.go
+++ b/imagick/magick_wand_image.go
@@ -12,6 +12,7 @@ package imagick
 import "C"
 
 import (
+	"errors"
 	"os"
 	"unsafe"
 )
@@ -2080,6 +2081,9 @@ func (mw *MagickWand) ReadImage(filename string) error {
 
 // Reads an image or image sequence from a blob.
 func (mw *MagickWand) ReadImageBlob(blob []byte) error {
+	if len(blob) == 0 {
+		return errors.New("zero-length blob not permitted")
+	}
 	C.MagickReadImageBlob(mw.mw, unsafe.Pointer(&blob[0]), C.size_t(len(blob)))
 	return mw.GetLastError()
 }

--- a/imagick/magick_wand_test.go
+++ b/imagick/magick_wand_test.go
@@ -72,6 +72,25 @@ func TestDeleteImageArtifact(t *testing.T) {
 	t.Log(err.Error())
 }
 
+func TestReadImageBlob(t *testing.T) {
+	mw = NewMagickWand()
+	defer mw.Destroy()
+
+	// Read an invalid blob
+	blob := []byte{}
+	if err := mw.ReadImageBlob(blob); err == nil {
+		t.Fatal("Expected a failure when passing a zero length blob")
+	}
+
+	mw.ReadImage(`logo:`)
+	blob = mw.GetImageBlob()
+
+	// Read a valid blob
+	if err := mw.ReadImageBlob(blob); err != nil {
+		t.Fatal(err.Error())
+	}
+}
+
 func TestGetImageFloats(t *testing.T) {
 	Initialize()
 	mw = NewMagickWand()


### PR DESCRIPTION
Since I was already into the codebase for other patches, I decided to submit this fix as well.

I used the second approach that was suggested, where the error is handled within the Go function. My opinion was that there was no point in making a CGO call when we know its going to fail. The error string mirrors what the C function would have returned in `GetLastError()`.
