### PR TITLE
Do not free an invalid pointer

### DIFF
--- a/imagick/magick_version.go
+++ b/imagick/magick_version.go
@@ -39,17 +39,17 @@ func GetReleaseDate() string {
 }
 
 // Returns the ImageMagick quantum depth as a string constant.
-func GetQuantumDepth() uint {
+func GetQuantumDepth() (string, uint) {
 	cst := C.size_t(0)
-	C.MagickGetQuantumDepth(&cst)
-	return uint(cst)
+	csq := C.MagickGetQuantumDepth(&cst)
+	return C.GoString(csq), uint(cst)
 }
 
 // Returns the ImageMagick quantum range as a string constant.
-func GetQuantumRange() uint {
+func GetQuantumRange() (string, uint) {
 	cst := C.size_t(0)
-	C.MagickGetQuantumRange(&cst)
-	return uint(cst)
+	csq := C.MagickGetQuantumRange(&cst)
+	return C.GoString(csq), uint(cst)
 }
 
 // Returns the specified resource in megabytes.


### PR DESCRIPTION
imagick is making my Go program panic when trying to get QuantumRange/Depth.

Looking to the code, imagick is trying to free what seems to be an invalid pointer. I'm not sure why we're even interested in this return value.

My fix consists of not collecting this return value and not freeing it.
