### PR TITLE
fixed to memory leak, QueryFonts, QueryFormats, GetImageArtifacts, GetImageProfiles, GetImageProperties, GetOptions

### DIFF
--- a/imagick/conversions.go
+++ b/imagick/conversions.go
@@ -35,6 +35,7 @@ func cStringArrayToStringSlice(p **C.char) []string {
 
 func sizedCStringArrayToStringSlice(p **C.char, num C.size_t) []string {
 	var strings []string
+	defer C.free(unsafe.Pointer(p))
 	q := uintptr(unsafe.Pointer(p))
 	for i := 0; i < int(num); i++ {
 		p = (**C.char)(unsafe.Pointer(q))

--- a/imagick/magick_wand.go
+++ b/imagick/magick_wand.go
@@ -84,7 +84,6 @@ func (mw *MagickWand) QueryConfigureOptions(pattern string) (options []string) {
 	defer C.free(unsafe.Pointer(cspattern))
 	var num C.size_t
 	copts := C.MagickQueryConfigureOptions(cspattern, &num)
-	defer C.free(unsafe.Pointer(copts))
 	options = sizedCStringArrayToStringSlice(copts, num)
 	return
 }


### PR DESCRIPTION
* free to strings array on sizedCStringArrayToStringSlice.
* callers to sizedCStringArrayToStringSlice
  - QueryConfigureOptions : free excute <= dismiss!
  - QueryFonts        : no free
  - QueryFormats      : no free
  - GetImageArtifacts : no free
  - GetImageProfiles  : no free
  - GetImageProperties: no free
  - GetOptions        : no free