### PR TITLE
fixed to memory leak, string array issue.

### DIFF
--- a/imagick/conversions.go
+++ b/imagick/conversions.go
@@ -18,6 +18,19 @@ func b2i(boolean bool) C.MagickBooleanType {
 	return C.MagickBooleanType(0)
 }
 
+func freeCStringArray(p **C.char) {
+	defer C.free(unsafe.Pointer(p))
+	q := uintptr(unsafe.Pointer(p))
+	for {
+		p = (**C.char)(unsafe.Pointer(q))
+		if *p == nil {
+			break
+		}
+		defer C.free(unsafe.Pointer(*p))
+		q += unsafe.Sizeof(q)
+	}
+}
+
 func cStringArrayToStringSlice(p **C.char) []string {
 	var strings []string
 	q := uintptr(unsafe.Pointer(p))
@@ -26,7 +39,6 @@ func cStringArrayToStringSlice(p **C.char) []string {
 		if *p == nil {
 			break
 		}
-		defer C.free(unsafe.Pointer(*p))
 		strings = append(strings, C.GoString(*p))
 		q += unsafe.Sizeof(q)
 	}
@@ -41,7 +53,6 @@ func sizedCStringArrayToStringSlice(p **C.char, num C.size_t) []string {
 		if *p == nil {
 			break
 		}
-		defer C.free(unsafe.Pointer(*p))
 		strings = append(strings, C.GoString(*p))
 		q += unsafe.Sizeof(q)
 	}

--- a/imagick/magick_wand.go
+++ b/imagick/magick_wand.go
@@ -84,7 +84,7 @@ func (mw *MagickWand) QueryConfigureOptions(pattern string) (options []string) {
 	defer C.free(unsafe.Pointer(cspattern))
 	var num C.size_t
 	copts := C.MagickQueryConfigureOptions(cspattern, &num)
-	defer C.free(unsafe.Pointer(copts))
+	defer freeCStringArray(copts)
 	options = sizedCStringArrayToStringSlice(copts, num)
 	return
 }
@@ -115,6 +115,7 @@ func (mw *MagickWand) QueryFonts(pattern string) (fonts []string) {
 	defer C.free(unsafe.Pointer(cspattern))
 	var num C.size_t
 	copts := C.MagickQueryFonts(cspattern, &num)
+	defer freeCStringArray(copts)
 	fonts = sizedCStringArrayToStringSlice(copts, num)
 	return
 }
@@ -125,6 +126,7 @@ func (mw *MagickWand) QueryFormats(pattern string) (formats []string) {
 	defer C.free(unsafe.Pointer(cspattern))
 	var num C.size_t
 	copts := C.MagickQueryFormats(cspattern, &num)
+	defer freeCStringArray(copts)
 	formats = sizedCStringArrayToStringSlice(copts, num)
 	return
 }

--- a/imagick/magick_wand_prop.go
+++ b/imagick/magick_wand_prop.go
@@ -106,6 +106,7 @@ func (mw *MagickWand) GetImageArtifacts(pattern string) (artifacts []string) {
 	defer C.free(unsafe.Pointer(cspattern))
 	num := C.size_t(0)
 	p := C.MagickGetImageArtifacts(mw.mw, cspattern, &num)
+	defer freeCStringArray(p)
 	artifacts = sizedCStringArrayToStringSlice(p, num)
 	return
 }
@@ -130,6 +131,7 @@ func (mw *MagickWand) GetImageProfiles(pattern string) (profiles []string) {
 	defer C.free(unsafe.Pointer(cspattern))
 	np := C.size_t(0)
 	ps := C.MagickGetImageProfiles(mw.mw, cspattern, &np)
+	defer freeCStringArray(ps)
 	profiles = sizedCStringArrayToStringSlice(ps, np)
 	return
 }
@@ -151,6 +153,7 @@ func (mw *MagickWand) GetImageProperties(pattern string) (properties []string) {
 	defer C.free(unsafe.Pointer(cspattern))
 	np := C.size_t(0)
 	ps := C.MagickGetImageProperties(mw.mw, cspattern, &np)
+	defer freeCStringArray(ps)
 	properties = sizedCStringArrayToStringSlice(ps, np)
 	return
 }


### PR DESCRIPTION
fixing to memory leak, QueryFonts, QueryFormats, GetImageArtifacts, GetImageProfiles, GetImageProperties, GetOptions

- add func freeCStringArray
- remove free call from string convert function
  - cStringArrayToStringSlice (unused from imagick package)
  - sizedCStringArrayToStringSlice (7 functions call this)
- add freeCStringArray call to 7 callers to sizedCStringArrayToStringSlice.
  - QueryConfigureOptions (replace free to freeCStringArray)
  - QueryFonts
  - QueryFormats
  - GetImageArtifacts
  - GetImageProfiles
  - GetImageProperties
  - GetOptions