### PR TITLE
Fix index panic when use unsafe.Pointer(&blob[0])

### DIFF
--- a/imagick/magick_wand_image.go
+++ b/imagick/magick_wand_image.go
@@ -763,8 +763,13 @@ func (mw *MagickWand) EvaluateImageChannel(channel ChannelType, op EvaluateOpera
 //
 func (mw *MagickWand) ExportImagePixels(x, y int, cols, rows uint,
 	pmap string, stype StorageType) (interface{}, error) {
-
+	if len(pmap) == 0 {
+		return nil, errors.New("zero-length pmap not permitted")
+	}
 	maplen := (int(cols) - x) * (int(rows) - y) * len(pmap)
+	if maplen <= 0 {
+		return nil, errors.New("Args x, y, cols, and rows produces an invalid region <= 0")
+	}
 
 	var (
 		pixel_iface interface{}
@@ -1980,6 +1985,9 @@ func (mw *MagickWand) PingImage(filename string) error {
 
 // Pings an image or image sequence from a blob.
 func (mw *MagickWand) PingImageBlob(blob []byte) error {
+	if len(blob) == 0 {
+		return errors.New("zero-length blob not permitted")
+	}
 	ok := C.MagickPingImageBlob(mw.mw, unsafe.Pointer(&blob[0]), C.size_t(len(blob)))
 	return mw.getLastErrorIfFailed(ok)
 }

--- a/imagick/magick_wand_prop.go
+++ b/imagick/magick_wand_prop.go
@@ -10,6 +10,7 @@ package imagick
 import "C"
 import (
 	//"fmt"
+	"errors"
 	"unsafe"
 )
 
@@ -252,6 +253,9 @@ func (mw *MagickWand) GetType() ImageType {
 // name: Name of profile to add or remove: ICC, IPTC, or generic profile.
 //
 func (mw *MagickWand) ProfileImage(name string, profile []byte) error {
+	if len(profile) == 0 {
+		return errors.New("zero-length profile not permitted")
+	}
 	csname := C.CString(name)
 	defer C.free(unsafe.Pointer(csname))
 	ok := C.MagickProfileImage(mw.mw, csname, unsafe.Pointer(&profile[0]), C.size_t(len(profile)))
@@ -362,6 +366,9 @@ func (mw *MagickWand) SetImageArtifact(artifact, value string) error {
 //
 // name: Name of profile to add or remove: ICC, IPTC, or generic profile.
 func (mw *MagickWand) SetImageProfile(name string, profile []byte) error {
+	if len(profile) == 0 {
+		return errors.New("zero-length profile not permitted")
+	}
 	csname := C.CString(name)
 	defer C.free(unsafe.Pointer(csname))
 	ok := C.MagickSetImageProfile(mw.mw, csname, unsafe.Pointer(&profile[0]), C.size_t(len(profile)))


### PR DESCRIPTION
When I use `PingImageBlob()` and the `blob` is zero length, my process panic with `runtime error: index out of range`. I found you miss index check in these codes:
```
unsafe.Pointer(&blob[0])
unsafe.Pointer(&pixels[0])
unsafe.Pointer(&profile[0])
```
This PR add index check before using &blob[0].
This bug exists in both master and im-6.8.9 branch.