### PR TITLE
uncomment OptimizeImageTransparency on the 6.8.9 branch

### DIFF
--- a/imagick/magick_wand_image.go
+++ b/imagick/magick_wand_image.go
@@ -1923,10 +1923,10 @@ func (mw *MagickWand) OptimizeImageLayers() *MagickWand {
 // not effect the outcome of an overlay) is made transparent.
 // WARNING: This modifies the current images directly, rather than generate a
 // new image sequence.
-//func (mw *MagickWand) OptimizeImageTransparency() error {
-//	ok := C.MagickOptimizeImageTransparency(mw.mw)
-//	return mw.getLastErrorIfFailed(ok)
-//}
+func (mw *MagickWand) OptimizeImageTransparency() error {
+	ok := C.MagickOptimizeImageTransparency(mw.mw)
+	return mw.getLastErrorIfFailed(ok)
+}
 
 // Performs an ordered dither based on a number of pre-defined dithering
 // threshold maps, but over multiple intensity levels, which can be different


### PR DESCRIPTION
In 6.8.9+ this function is available so it doesn't need to be commented out.