### PR TITLE
change function signature of ConstituteImage

### DIFF
--- a/imagick/magick_wand_image.go
+++ b/imagick/magick_wand_image.go
@@ -1529,7 +1529,7 @@ func pixelInterfaceToPtr(pixels interface{}) (unsafe.Pointer, StorageType, error
 		stype = PIXEL_LONG
 
 	default:
-		return ptr, nil, fmt.Errorf("Type %T is not valid for this operation", t)
+		return ptr, PIXEL_UNDEFINED, fmt.Errorf("Type %T is not valid for this operation", t)
 	}
 
 	return ptr, stype, nil

--- a/imagick/magick_wand_image.go
+++ b/imagick/magick_wand_image.go
@@ -558,10 +558,17 @@ func (mw *MagickWand) CycleColormapImage(displace int) error {
 // pixels: This array of values contain the pixel components as defined by the
 // type.
 //
-func (mw *MagickWand) ConstituteImage(cols, rows uint, pmap string, stype StorageType, pixels []interface{}) error {
+func (mw *MagickWand) ConstituteImage(cols, rows uint, pmap string, stype StorageType, pixels interface{}) error {
 	cspmap := C.CString(pmap)
 	defer C.free(unsafe.Pointer(cspmap))
-	ok := C.MagickConstituteImage(mw.mw, C.size_t(cols), C.size_t(rows), cspmap, C.StorageType(stype), unsafe.Pointer(&pixels[0]))
+	ptr, calculatedStype, err := pixelInterfaceToPtr(pixels)
+	if err != nil {
+		return err
+	}
+	if stype == PIXEL_UNDEFINED {
+		stype = calculatedStype
+	}
+	ok := C.MagickConstituteImage(mw.mw, C.size_t(cols), C.size_t(rows), cspmap, C.StorageType(stype), ptr)
 	return mw.getLastErrorIfFailed(ok)
 }
 
@@ -1483,6 +1490,51 @@ func (mw *MagickWand) ImplodeImage(radius float64) error {
 	return mw.getLastErrorIfFailed(ok)
 }
 
+// Identifies the type of pixels and returns the storage type and an
+// unsafe pointer to the data.
+func pixelInterfaceToPtr(pixels interface{}) (unsafe.Pointer, StorageType, error) {
+	var ptr unsafe.Pointer
+	var stype StorageType
+
+	switch t := pixels.(type) {
+
+	case []byte:
+		v := &t[0]
+		ptr = unsafe.Pointer(v)
+		stype = PIXEL_CHAR
+
+	case []float64:
+		v := &t[0]
+		ptr = unsafe.Pointer(v)
+		stype = PIXEL_DOUBLE
+
+	case []float32:
+		v := &t[0]
+		ptr = unsafe.Pointer(v)
+		stype = PIXEL_FLOAT
+
+	case []int16:
+		v := &t[0]
+		ptr = unsafe.Pointer(v)
+		stype = PIXEL_SHORT
+
+	case []int32:
+		v := &t[0]
+		ptr = unsafe.Pointer(v)
+		stype = PIXEL_INTEGER
+
+	case []int64:
+		v := &t[0]
+		ptr = unsafe.Pointer(v)
+		stype = PIXEL_LONG
+
+	default:
+		return ptr, nil, fmt.Errorf("Type %T is not valid for this operation", t)
+	}
+
+	return ptr, stype, nil
+}
+
 // Accepts pixel data and stores it in the image at the location you specify.
 // The pixel data can be either byte, int16, int32, int64, float32, or float64
 // in the order specified by map. Suppose your want to upload the first
@@ -1521,53 +1573,12 @@ func (mw *MagickWand) ImportImagePixels(x, y int, cols, rows uint, pmap string,
 
 	var ptr unsafe.Pointer
 
-	switch t := pixels.(type) {
-
-	case []byte:
-		v := &t[0]
-		ptr = unsafe.Pointer(v)
-		if stype == PIXEL_UNDEFINED {
-			stype = PIXEL_CHAR
-		}
-
-	case []float64:
-		v := &t[0]
-		ptr = unsafe.Pointer(v)
-		if stype == PIXEL_UNDEFINED {
-			stype = PIXEL_DOUBLE
-		}
-
-	case []float32:
-		v := &t[0]
-		ptr = unsafe.Pointer(v)
-		if stype == PIXEL_UNDEFINED {
-			stype = PIXEL_FLOAT
-		}
-
-	case []int16:
-		v := &t[0]
-		ptr = unsafe.Pointer(v)
-		if stype == PIXEL_UNDEFINED {
-			stype = PIXEL_SHORT
-		}
-
-	case []int32:
-		v := &t[0]
-		ptr = unsafe.Pointer(v)
-		if stype == PIXEL_UNDEFINED {
-			stype = PIXEL_INTEGER
-		}
-
-	case []int64:
-		v := &t[0]
-		ptr = unsafe.Pointer(v)
-		if stype == PIXEL_UNDEFINED {
-			stype = PIXEL_LONG
-		}
-
-	default:
-		return fmt.Errorf("Type %T is not valid for this operation", t)
-
+	ptr, calculatedStype, err := pixelInterfaceToPtr(pixels)
+	if err != nil {
+		return err
+	}
+	if stype == PIXEL_UNDEFINED {
+		stype = calculatedStype
 	}
 
 	ok := C.MagickImportImagePixels(mw.mw, C.ssize_t(x), C.ssize_t(y), C.size_t(cols),

--- a/imagick/magick_wand_test.go
+++ b/imagick/magick_wand_test.go
@@ -5,6 +5,7 @@
 package imagick
 
 import (
+	"reflect"
 	"testing"
 )
 
@@ -217,4 +218,39 @@ func BenchmarkImportImagePixels(b *testing.B) {
 	}
 
 	b.StopTimer()
+}
+
+type testPixelInterfaceValues struct {
+	Pixels  interface{}
+	Storage StorageType
+}
+
+func TestPixelInterfaceToPtr(t *testing.T) {
+	Tests := make([]testPixelInterfaceValues, 6)
+	Tests[0].Pixels = []byte{0}
+	Tests[0].Storage = PIXEL_CHAR
+	Tests[1].Pixels = []float64{0}
+	Tests[1].Storage = PIXEL_DOUBLE
+	Tests[2].Pixels = []float32{0}
+	Tests[2].Storage = PIXEL_FLOAT
+	Tests[3].Pixels = []int16{0}
+	Tests[3].Storage = PIXEL_SHORT
+	Tests[4].Pixels = []int32{0}
+	Tests[4].Storage = PIXEL_INTEGER
+	Tests[5].Pixels = []int64{0}
+	Tests[5].Storage = PIXEL_LONG
+	for _, value := range Tests {
+		_, storageType, err := pixelInterfaceToPtr(value.Pixels)
+		if err != nil {
+			t.Fatal("Error when passing", reflect.TypeOf(value.Pixels))
+		}
+		if storageType != value.Storage {
+			t.Fatal("Wrong storage type received for", reflect.TypeOf(value.Pixels))
+		}
+	}
+
+	_, _, err := pixelInterfaceToPtr(32)
+	if err == nil {
+		t.Fatal("Expected error when passing invalid type")
+	}
 }

--- a/imagick/magick_wand_test.go
+++ b/imagick/magick_wand_test.go
@@ -220,32 +220,25 @@ func BenchmarkImportImagePixels(b *testing.B) {
 	b.StopTimer()
 }
 
-type testPixelInterfaceValues struct {
-	Pixels  interface{}
-	Storage StorageType
-}
-
 func TestPixelInterfaceToPtr(t *testing.T) {
-	Tests := make([]testPixelInterfaceValues, 6)
-	Tests[0].Pixels = []byte{0}
-	Tests[0].Storage = PIXEL_CHAR
-	Tests[1].Pixels = []float64{0}
-	Tests[1].Storage = PIXEL_DOUBLE
-	Tests[2].Pixels = []float32{0}
-	Tests[2].Storage = PIXEL_FLOAT
-	Tests[3].Pixels = []int16{0}
-	Tests[3].Storage = PIXEL_SHORT
-	Tests[4].Pixels = []int32{0}
-	Tests[4].Storage = PIXEL_INTEGER
-	Tests[5].Pixels = []int64{0}
-	Tests[5].Storage = PIXEL_LONG
-	for _, value := range Tests {
-		_, storageType, err := pixelInterfaceToPtr(value.Pixels)
+	tests := []struct {
+		pixels  interface{}
+		storage StorageType
+	}{
+		{[]byte{0}, PIXEL_CHAR},
+		{[]float64{0}, PIXEL_DOUBLE},
+		{[]float32{0}, PIXEL_FLOAT},
+		{[]int16{0}, PIXEL_SHORT},
+		{[]int32{0}, PIXEL_INTEGER},
+		{[]int64{0}, PIXEL_LONG},
+	}
+	for _, value := range tests {
+		_, storageType, err := pixelInterfaceToPtr(value.pixels)
 		if err != nil {
-			t.Fatal("Error when passing", reflect.TypeOf(value.Pixels))
+			t.Fatal("Error when passing", reflect.TypeOf(value.pixels))
 		}
-		if storageType != value.Storage {
-			t.Fatal("Wrong storage type received for", reflect.TypeOf(value.Pixels))
+		if storageType != value.storage {
+			t.Fatal("Wrong storage type received for", reflect.TypeOf(value.pixels))
 		}
 	}
 


### PR DESCRIPTION
This commit also refactors the type assertion from ImportImagePixels into a separate function that both ImportImagePixels and ConstituteImage consume.

fixes #76 