### PR TITLE
Make mw, pi, pw, dw objects destroyable in GO GC (replaces #62)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ The examples folder is full with usage examples ported from C ones found in here
 # Quick and partial example
 
 Since this is a CGO binding, Go GC does not manage memory allocated by the C API then is necessary to use Terminate() and Destroy() methods.
+But objects of MagickWand, DrawingWand, PixelIterator and PixelWand are managed by GO GC if you create them by constructors.
 
 ```
 package main
@@ -74,7 +75,61 @@ func main() {
     defer imagick.Terminate()
 
     mw := imagick.NewMagickWand()
+
+    ...
+}
+```
+
+If you use struct literals, you should free resources manually:
+
+```
+package main
+
+import "github.com/gographics/imagick/imagick"
+
+func main() {
+    imagick.Initialize()
+    defer imagick.Terminate()
+
+    mw := imagick.MagickWand{...}
     defer mw.Destroy()
+
+    ...
+}
+```
+
+Both methods are compatible if constructor methods used:
+
+```
+package main
+
+import "github.com/gographics/imagick/imagick"
+
+func main() {
+    imagick.Initialize()
+    defer imagick.Terminate()
+
+    mw := imagick.NewMagickWand()
+    defer mw.Destroy()
+
+    ...
+}
+```
+
+But you should NOT mix two ways of object creation:
+```
+package main
+
+import "github.com/gographics/imagick/imagick"
+
+func main() {
+    imagick.Initialize()
+    defer imagick.Terminate()
+
+    mw1 := imagick.MagickWand{...}
+    defer mw1.Destroy()
+
+    mw2 := imagick.NewMagickWand()
 
     ...
 }

--- a/examples/3dlogo/main.go
+++ b/examples/3dlogo/main.go
@@ -12,11 +12,8 @@ func main() {
 	defer imagick.Terminate()
 
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 	pw := imagick.NewPixelWand()
-	defer pw.Destroy()
 	dw := imagick.NewDrawingWand()
-	defer dw.Destroy()
 
 	if err := mw.SetSize(170, 100); err != nil {
 		panic(err)
@@ -67,7 +64,6 @@ func main() {
 	dw = imagick.NewDrawingWand()
 
 	mwc := imagick.NewMagickWand()
-	defer mwc.Destroy()
 
 	mw.ReadImage("logo_mask.png")
 
@@ -108,7 +104,6 @@ func main() {
 	if err != nil {
 		panic(err)
 	}
-	defer mwf.Destroy()
 
 	//mw.SetImageMatte(false)
 
@@ -206,7 +201,7 @@ func main() {
 
 	// It seems that this must be a separate pixelwand for Colorize to work!
 	pwo := imagick.NewPixelWand()
-	defer pwo.Destroy()
+
 	// AHA .. this is how to do a 60% colorize
 	pwo.SetColor("rgb(60%,60%,60%)")
 	mwf.ColorizeImage(pw, pwo)

--- a/examples/affine/main.go
+++ b/examples/affine/main.go
@@ -98,7 +98,6 @@ func example1() {
 	result := make([]float64, 6)
 
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 
 	mw.ReadImage("logo:")
 
@@ -142,7 +141,6 @@ func example2() {
 	result := make([]float64, 6)
 
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 
 	mw.ReadImage("logo:")
 
@@ -193,7 +191,6 @@ func example3() {
 	var angle_degrees float64
 
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 
 	mw.ReadImage("logo:")
 	w := mw.GetImageWidth()
@@ -259,7 +256,6 @@ func example4() {
 	}
 
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 	mw.SetSize(gw, gh)
 	mw.ReadImage("gradient:white-black")
 

--- a/examples/bunny/main.go
+++ b/examples/bunny/main.go
@@ -10,9 +10,7 @@ func main() {
 	defer imagick.Terminate()
 
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 	aw := imagick.NewMagickWand()
-	defer aw.Destroy()
 
 	// Read the first input image
 	if err := mw.ReadImage("bunny_grass.gif"); err != nil {

--- a/examples/clipmask/main.go
+++ b/examples/clipmask/main.go
@@ -10,13 +10,8 @@ func main() {
 	defer imagick.Terminate()
 
 	dest := imagick.NewMagickWand()
-	defer dest.Destroy()
-
 	src := imagick.NewMagickWand()
-	defer src.Destroy()
-
 	mask := imagick.NewMagickWand()
-	defer mask.Destroy()
 
 	dest.SetSize(100, 100)
 	src.SetSize(100, 100)

--- a/examples/cyclops/main.go
+++ b/examples/cyclops/main.go
@@ -12,11 +12,8 @@ func main() {
 	imagick.Initialize()
 	defer imagick.Terminate()
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 	bg := imagick.NewPixelWand()
-	defer bg.Destroy()
 	fg := imagick.NewPixelWand()
-	defer fg.Destroy()
 
 	err = mw.ReadImage("cyclops_sm.gif")
 	if err != nil {

--- a/examples/draw_shapes/main.go
+++ b/examples/draw_shapes/main.go
@@ -10,9 +10,7 @@ func main() {
 	defer imagick.Terminate()
 
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 	dw := imagick.NewDrawingWand()
-	defer dw.Destroy()
 	cw := imagick.NewPixelWand()
 
 	diameter := uint(640)

--- a/examples/extend/main.go
+++ b/examples/extend/main.go
@@ -14,10 +14,7 @@ func main() {
 	var err error
 
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
-
 	pw := imagick.NewPixelWand()
-	defer pw.Destroy()
 	pw.SetColor("blue")
 
 	err = mw.ReadImage("logo:")

--- a/examples/floodfill/main.go
+++ b/examples/floodfill/main.go
@@ -14,12 +14,9 @@ func main() {
 	var err error
 
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 
 	// fillcolor and bordercolor
 	fc, bc := imagick.NewPixelWand(), imagick.NewPixelWand()
-	defer fc.Destroy()
-	defer bc.Destroy()
 
 	fc.SetColor("none")
 	bc.SetColor("white")

--- a/examples/grayscale/main.go
+++ b/examples/grayscale/main.go
@@ -12,18 +12,15 @@ func main() {
 	defer imagick.Terminate()
 
 	pw := imagick.NewPixelWand()
-	defer pw.Destroy()
 	pw.SetColor("white")
 
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 
 	// Create a 100x100 image with a default of white
 	mw.NewImage(100, 100, pw)
 
 	// Get a new pixel iterator
 	iterator := mw.NewPixelIterator()
-	defer iterator.Destroy()
 
 	for y := 0; y < int(mw.GetImageHeight()); y++ {
 		// Get the next row of the image as an array of PixelWands

--- a/examples/landscape3d/main.go
+++ b/examples/landscape3d/main.go
@@ -8,9 +8,7 @@ func main() {
 	defer imagick.Terminate()
 
 	image := imagick.NewMagickWand()
-	defer image.Destroy()
 	pw := imagick.NewPixelWand()
-	defer pw.Destroy()
 
 	image.ReadImage("fract6.jpg")
 
@@ -37,7 +35,7 @@ func main() {
 
 	// Make a blank canvas to draw on
 	canvas := imagick.NewMagickWand()
-	defer canvas.Destroy()
+
 	// Use a colour from the input image
 	pw, err := image.GetImagePixelColor(0, 0)
 	if err != nil {

--- a/examples/pixel_mod/main.go
+++ b/examples/pixel_mod/main.go
@@ -14,13 +14,12 @@ func useDraw() {
 
 	/* Create a wand */
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
+
 	/* Read the input image */
 	mw.ReadImage("logo:")
 	fill := imagick.NewPixelWand()
-	defer fill.Destroy()
 	dw := imagick.NewDrawingWand()
-	defer dw.Destroy()
+
 	// Set the fill to "red" or you can do the same thing with this:
 	fill.SetColor("red")
 	dw.SetFillColor(fill)
@@ -37,13 +36,11 @@ func usePixelIterator() {
 
 	/* Create a wand */
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 
 	/* Read the input image */
 	mw.ReadImage("logo:")
 	// Get a one-pixel region at coordinate 200,100
 	iterator := mw.NewPixelRegionIterator(200, 100, 1, 1)
-	defer iterator.Destroy()
 	pixels := iterator.GetNextIteratorRow()
 	// Modify the pixel
 	pixels[0].SetColor("red")

--- a/examples/reflect/main.go
+++ b/examples/reflect/main.go
@@ -8,7 +8,6 @@ func main() {
 	defer imagick.Terminate()
 
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 	mw.ReadImage("logo:")
 
 	// We know that logo: is 640x480 but in the general case
@@ -22,7 +21,7 @@ func main() {
 	mw.SetImageAlphaChannel(imagick.ALPHA_CHANNEL_DEACTIVATE)
 	// clone the input image
 	mwr := mw.Clone()
-	defer mwr.Destroy()
+
 	// Resize it
 	mwr.ResizeImage(w, h/2, imagick.FILTER_LANCZOS, 1)
 	// Flip the image over to form the reflection
@@ -31,7 +30,6 @@ func main() {
 	// Create the gradient image which will be used as the alpha
 	// channel in the reflection image
 	mwg := imagick.NewMagickWand()
-	defer mwg.Destroy()
 	mwg.SetSize(w, h/2)
 	mwg.ReadImage("gradient:white-black")
 
@@ -43,7 +41,6 @@ func main() {
 
 	// Append the reflection to the bottom (MagickTrue) of the original image
 	mwout := mw.AppendImages(true)
-	defer mwout.Destroy()
 
 	// and save the result
 	mwout.WriteImage("logo_reflect.png")

--- a/examples/resize/main.go
+++ b/examples/resize/main.go
@@ -14,8 +14,6 @@ func main() {
 	var err error
 
 	mw := imagick.NewMagickWand()
-	// Schedule cleanup
-	defer mw.Destroy()
 
 	err = mw.ReadImage("logo:")
 	if err != nil {

--- a/examples/round_mask/main.go
+++ b/examples/round_mask/main.go
@@ -8,13 +8,9 @@ func main() {
 	defer imagick.Terminate()
 
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 	lw := imagick.NewMagickWand()
-	defer lw.Destroy()
 	pw := imagick.NewPixelWand()
-	defer pw.Destroy()
 	dw := imagick.NewDrawingWand()
-	defer dw.Destroy()
 
 	// Create the initial 640x480 transparent canvas
 	pw.SetColor("none")

--- a/examples/text_effects/main.go
+++ b/examples/text_effects/main.go
@@ -8,7 +8,6 @@ import "gopkg.in/gographics/imagick.v2/imagick"
 // Currently only used in Text Effect 2
 func setTilePattern(dw *imagick.DrawingWand, pattern_name, pattern_file string) {
 	tw := imagick.NewMagickWand()
-	defer tw.Destroy()
 
 	tw.ReadImage(pattern_file)
 	// Read the tile's width and height
@@ -41,11 +40,9 @@ func textEffect1() {
 	imagick.Initialize()
 	defer imagick.Terminate()
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 	dw := imagick.NewDrawingWand()
-	defer dw.Destroy()
 	pw := imagick.NewPixelWand()
-	defer pw.Destroy()
+
 	pw.SetColor("none")
 	// Create a new transparent image
 	mw.NewImage(350, 100, pw)
@@ -78,7 +75,7 @@ func textEffect1() {
 	mw.CompositeImage(cw, imagick.COMPOSITE_OP_OVER, 5, 5)
 	cw.Destroy()
 	cw = imagick.NewMagickWand()
-	defer cw.Destroy()
+
 	// Create a new image the same size as the text image and put a solid colour
 	// as its background
 	pw.SetColor("rgb(125,215,255)")
@@ -95,11 +92,8 @@ func textEffect2() {
 	imagick.Initialize()
 	defer imagick.Terminate()
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 	dw := imagick.NewDrawingWand()
-	defer dw.Destroy()
 	pw := imagick.NewPixelWand()
-	defer pw.Destroy()
 	setTilePattern(dw, "#check", "pattern:checkerboard")
 	pw.SetColor("lightblue")
 	// Create a new transparent image
@@ -125,11 +119,8 @@ func textEffect3() {
 	imagick.Initialize()
 	defer imagick.Terminate()
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 	dw := imagick.NewDrawingWand()
-	defer dw.Destroy()
 	pw := imagick.NewPixelWand()
-	defer pw.Destroy()
 	// Create a 320x100 lightblue canvas
 	pw.SetColor("lightblue")
 	mw.NewImage(320, 100, pw)
@@ -155,11 +146,8 @@ func textEffect4() {
 	imagick.Initialize()
 	defer imagick.Terminate()
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 	dw := imagick.NewDrawingWand()
-	defer dw.Destroy()
 	pw := imagick.NewPixelWand()
-	defer pw.Destroy()
 	// Create a 320x100 canvas
 	pw.SetColor("gray")
 	mw.NewImage(320, 100, pw)
@@ -178,7 +166,6 @@ func textEffect4() {
 	pw.SetColor("yellow")
 	dw.SetFillColor(pw)
 	cpw := imagick.NewPixelWand()
-	defer cpw.Destroy()
 	cpw.SetColor("gold")
 	mw.ColorizeImage(pw, cpw)
 	// and write it
@@ -191,11 +178,8 @@ func textEffect5And6() {
 	defer imagick.Terminate()
 	// This one uses d_args
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 	dw := imagick.NewDrawingWand()
-	defer dw.Destroy()
 	pw := imagick.NewPixelWand()
-	defer pw.Destroy()
 	// Create a 320x100 transparent canvas
 	pw.SetColor("none")
 	mw.NewImage(320, 100, pw)
@@ -251,11 +235,8 @@ func textEffect7() {
 	defer imagick.Terminate()
 	// This one uses d_args[0]
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 	dw := imagick.NewDrawingWand()
-	defer dw.Destroy()
 	pw := imagick.NewPixelWand()
-	defer pw.Destroy()
 	// Create a 320x200 transparent canvas
 	pw.SetColor("none")
 	mw.NewImage(320, 200, pw)
@@ -285,11 +266,8 @@ func textEffect8() {
 	defer imagick.Terminate()
 	// This one uses d_args[0]
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 	dw := imagick.NewDrawingWand()
-	defer dw.Destroy()
 	pw := imagick.NewPixelWand()
-	defer pw.Destroy()
 	// Create a 320x200 transparent canvas
 	pw.SetColor("none")
 	mw.NewImage(640, 480, pw)

--- a/examples/tilt_shift/main.go
+++ b/examples/tilt_shift/main.go
@@ -19,7 +19,6 @@ func main() {
 	imagick.Initialize()
 	defer imagick.Terminate()
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 	if err := mw.ReadImage("beijing_md.jpg"); err != nil {
 		panic(err)
 	}
@@ -28,7 +27,6 @@ func main() {
 	_, quant := imagick.GetQuantumRange()
 	mw.SigmoidalContrastImage(true, 15, float64(quant)*30/100)
 	cw := mw.Clone()
-	defer cw.Destroy()
 	cw.SparseColorImage(imagick.CHANNELS_RGB, imagick.INTERPOLATE_BARYCENTRIC_COLOR, arglist)
 	// Do the polynomial function
 	cw.FunctionImage(imagick.FUNCTION_POLYNOMIAL, funclist)

--- a/examples/trans_paint/main.go
+++ b/examples/trans_paint/main.go
@@ -8,7 +8,6 @@ func main() {
 	defer imagick.Terminate()
 
 	mw := imagick.NewMagickWand()
-	defer mw.Destroy()
 	mw.ReadImage("logo:")
 
 	// A larger fuzz value allows more colours "near" white to be
@@ -17,7 +16,6 @@ func main() {
 	// Set up the pixelwand containing the colour to be "targeted"
 	// by transparency
 	target := imagick.NewPixelWand()
-	defer target.Destroy()
 	target.SetColor("white")
 	// Change the transparency of all colours which match target (with
 	// fuzz applied). In this case they are made completely transparent (0)

--- a/imagick/destroy.go
+++ b/imagick/destroy.go
@@ -1,0 +1,9 @@
+package imagick
+
+import "github.com/gographics/imagick/imagick/types"
+
+// Destroy instance of Destroyer
+// If GOGC=off you should call obj.Destroy() manually
+func Destroy(d types.Destroyer) {
+	d.Destroy()
+}

--- a/imagick/destroy.go
+++ b/imagick/destroy.go
@@ -1,6 +1,6 @@
 package imagick
 
-import "github.com/gographics/imagick/imagick/types"
+import "gopkg.in/gographics/imagick.v2/imagick/types"
 
 // Destroy instance of Destroyer
 // If GOGC=off you should call obj.Destroy() manually

--- a/imagick/drawing_wand.go
+++ b/imagick/drawing_wand.go
@@ -16,8 +16,8 @@ import (
 )
 
 type DrawingWand struct {
-	dw *C.DrawingWand
-	sync.Once
+	dw   *C.DrawingWand
+	init sync.Once
 }
 
 func newDrawingWand(cdw *C.DrawingWand) *DrawingWand {
@@ -50,7 +50,7 @@ func (dw *DrawingWand) Destroy() {
 		return
 	}
 
-	dw.Do(func() {
+	dw.init.Do(func() {
 		dw.dw = C.DestroyDrawingWand(dw.dw)
 		relinquishMemory(unsafe.Pointer(dw.dw))
 		dw.dw = nil

--- a/imagick/drawing_wand.go
+++ b/imagick/drawing_wand.go
@@ -9,16 +9,28 @@ package imagick
 */
 import "C"
 import (
+	"runtime"
+	"sync"
+	"sync/atomic"
 	"unsafe"
 )
 
 type DrawingWand struct {
 	dw *C.DrawingWand
+	sync.Once
+}
+
+func newDrawingWand(cdw *C.DrawingWand) *DrawingWand {
+	dw := &DrawingWand{dw: cdw}
+	runtime.SetFinalizer(dw, Destroy)
+	dw.IncreaseCount()
+
+	return dw
 }
 
 // Returns a drawing wand required for all other methods in the API.
 func NewDrawingWand() *DrawingWand {
-	return &DrawingWand{C.NewDrawingWand()}
+	return newDrawingWand(C.NewDrawingWand())
 }
 
 // Clears resources associated with the drawing wand.
@@ -28,7 +40,7 @@ func (dw *DrawingWand) Clear() {
 
 // Makes an exact copy of the specified wand.
 func (dw *DrawingWand) Clone() *DrawingWand {
-	return &DrawingWand{C.CloneDrawingWand(dw.dw)}
+	return newDrawingWand(C.CloneDrawingWand(dw.dw))
 }
 
 // Frees all resources associated with the drawing wand. Once the drawing wand
@@ -37,10 +49,26 @@ func (dw *DrawingWand) Destroy() {
 	if dw.dw == nil {
 		return
 	}
-	dw.dw = C.DestroyDrawingWand(dw.dw)
-	relinquishMemory(unsafe.Pointer(dw.dw))
-	dw.dw = nil
 
+	dw.Do(func() {
+		dw.dw = C.DestroyDrawingWand(dw.dw)
+		relinquishMemory(unsafe.Pointer(dw.dw))
+		dw.dw = nil
+
+		dw.DecreaseCount()
+	})
+}
+
+// Increase DrawingWand ref counter and set according "can`t be terminated status"
+func (dw *DrawingWand) IncreaseCount() {
+	atomic.AddInt64(&drawingWandCounter, int64(1))
+	unsetCanTerminate()
+}
+
+// Decrease DrawingWand ref counter and set according "can be terminated status"
+func (dw *DrawingWand) DecreaseCount() {
+	atomic.AddInt64(&drawingWandCounter, int64(-1))
+	setCanTerminate()
 }
 
 // Adjusts the current affine transformation matrix with the specified affine

--- a/imagick/magick_wand.go
+++ b/imagick/magick_wand.go
@@ -11,23 +11,34 @@ import "C"
 
 import (
 	"fmt"
+	"runtime"
+	"sync"
+	"sync/atomic"
 	"unsafe"
 )
 
 // This struct represents the MagickWand C API of ImageMagick
 type MagickWand struct {
 	mw *C.MagickWand
+	sync.Once
+}
+
+func newMagickWand(cmw *C.MagickWand) *MagickWand {
+	mw := &MagickWand{mw: cmw}
+	runtime.SetFinalizer(mw, Destroy)
+	mw.IncreaseCount()
+
+	return mw
 }
 
 // Returns a wand required for all other methods in the API. A fatal exception is thrown if there is not enough memory to allocate the wand.
-// Use Destroy() to dispose of the wand then it is no longer needed.
 func NewMagickWand() *MagickWand {
-	return &MagickWand{C.NewMagickWand()}
+	return newMagickWand(C.NewMagickWand())
 }
 
-// Returns a wand with an image/
+// Returns a wand with an image
 func NewMagickWandFromImage(img *Image) *MagickWand {
-	return &MagickWand{C.NewMagickWandFromImage(img.img)}
+	return newMagickWand(C.NewMagickWandFromImage(img.img))
 }
 
 // Clear resources associated with the wand, leaving the wand blank, and ready to be used for a new set of images.
@@ -37,8 +48,7 @@ func (mw *MagickWand) Clear() {
 
 // Makes an exact copy of the MagickWand object
 func (mw *MagickWand) Clone() *MagickWand {
-	clone := C.CloneMagickWand(mw.mw)
-	return &MagickWand{clone}
+	return newMagickWand(C.CloneMagickWand(mw.mw))
 }
 
 // Deallocates memory associated with an MagickWand
@@ -46,9 +56,14 @@ func (mw *MagickWand) Destroy() {
 	if mw.mw == nil {
 		return
 	}
-	mw.mw = C.DestroyMagickWand(mw.mw)
-	relinquishMemory(unsafe.Pointer(mw.mw))
-	mw.mw = nil
+
+	mw.Do(func() {
+		mw.mw = C.DestroyMagickWand(mw.mw)
+		relinquishMemory(unsafe.Pointer(mw.mw))
+		mw.mw = nil
+
+		mw.DecreaseCount()
+	})
 }
 
 // Returns true if the wand is a verified magick wand
@@ -57,6 +72,18 @@ func (mw *MagickWand) IsVerified() bool {
 		return 1 == C.int(C.IsMagickWand(mw.mw))
 	}
 	return false
+}
+
+// Increase MagickWand ref counter and set according "can`t be terminated status"
+func (mw *MagickWand) IncreaseCount() {
+	atomic.AddInt64(&magickWandCounter, int64(1))
+	unsetCanTerminate()
+}
+
+// Decrease MagickWand ref counter and set according "can be terminated status"
+func (mw *MagickWand) DecreaseCount() {
+	atomic.AddInt64(&magickWandCounter, int64(-1))
+	setCanTerminate()
 }
 
 // Returns the position of the iterator in the image list

--- a/imagick/magick_wand.go
+++ b/imagick/magick_wand.go
@@ -19,8 +19,8 @@ import (
 
 // This struct represents the MagickWand C API of ImageMagick
 type MagickWand struct {
-	mw *C.MagickWand
-	sync.Once
+	mw   *C.MagickWand
+	init sync.Once
 }
 
 func newMagickWand(cmw *C.MagickWand) *MagickWand {
@@ -57,7 +57,7 @@ func (mw *MagickWand) Destroy() {
 		return
 	}
 
-	mw.Do(func() {
+	mw.init.Do(func() {
 		mw.mw = C.DestroyMagickWand(mw.mw)
 		relinquishMemory(unsafe.Pointer(mw.mw))
 		mw.mw = nil

--- a/imagick/magick_wand_env.go
+++ b/imagick/magick_wand_env.go
@@ -8,24 +8,93 @@ package imagick
 #include <wand/MagickWand.h>
 */
 import "C"
-
-var (
-	initialized bool
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
 )
 
-// Inicializes the MagickWand environment
+var (
+	initOnce      sync.Once
+	terminateOnce *sync.Once
+
+	// Indicates that terminate method can be called (there are no any ImageMagick objects)
+	canTerminate = make(chan struct{}, 1)
+
+	envSemaphore = make(chan struct{}, 1)
+
+	// Ref counters
+	magickWandCounter    int64
+	drawingWandCounter   int64
+	pixelIteratorCounter int64
+	pixelWandCounter     int64
+)
+
+// Initializes the MagickWand environment
 func Initialize() {
-	if initialized {
-		return
-	}
-	C.MagickWandGenesis()
-	initialized = true
+	envSemaphore <- struct{}{}
+	defer func() {
+		<-envSemaphore
+	}()
+
+	initOnce.Do(func() {
+		C.MagickWandGenesis()
+		terminateOnce = &sync.Once{}
+		setCanTerminate()
+	})
 }
 
 // Terminates the MagickWand environment
+// wait until all imageMagick objects destroyed
 func Terminate() {
-	if initialized {
-		C.MagickWandTerminus()
-		initialized = false
+	envSemaphore <- struct{}{}
+	defer func() {
+		<-envSemaphore
+	}()
+
+	if terminateOnce != nil {
+		terminateOnce.Do(func() {
+			runtime.GC()
+			terminate()
+		})
 	}
+}
+
+// Guarantees that C.MagickWandTerminus run after all ImageMagick objects are destroyed
+// or we got the panic from C.MagickWandTerminus
+func terminate() {
+	<-canTerminate
+	C.MagickWandTerminus()
+	initOnce = sync.Once{}
+}
+
+// Set status "terminate can be called"
+func setCanTerminate() {
+	if isImageMagickCleaned() {
+		select {
+		case canTerminate <- struct{}{}:
+			// Now we can terminate
+		default:
+			// Nothing to do
+		}
+	}
+}
+
+// Set status "terminate can`t be called"
+func unsetCanTerminate() {
+	select {
+	case <-canTerminate:
+		// Now we can`t terminate
+	default:
+		// Nothing to do
+	}
+}
+
+// Check are all IM objects are collected by GC
+func isImageMagickCleaned() bool {
+	if atomic.LoadInt64(&magickWandCounter) != 0 || atomic.LoadInt64(&drawingWandCounter) != 0 || atomic.LoadInt64(&pixelIteratorCounter) != 0 || atomic.LoadInt64(&pixelWandCounter) != 0 {
+		return false
+	}
+
+	return true
 }

--- a/imagick/magick_wand_env_test.go
+++ b/imagick/magick_wand_env_test.go
@@ -7,20 +7,15 @@ package imagick
 import "testing"
 
 func TestEnvironmentLifecycle(t *testing.T) {
+	defer func() {
+		if reco := recover(); reco != nil {
+			t.Fatalf("MagickWand environment was not correctly inited or terminated: %q", reco)
+		}
+	}()
+
 	Initialize()
-	if !initialized {
-		t.Fatal("MagickWand environment was not initialized")
-	}
 	Initialize()
-	if !initialized {
-		t.Fatal("MagickWand environment was not idenpotently initialized")
-	}
+
 	Terminate()
-	if initialized {
-		t.Fatal("MagickWand environment was not terminated")
-	}
 	Terminate()
-	if initialized {
-		t.Fatal("MagickWand environment was not idenpotently terminated")
-	}
 }

--- a/imagick/magick_wand_image.go
+++ b/imagick/magick_wand_image.go
@@ -163,7 +163,7 @@ func (mw *MagickWand) AnimateImages(server string) error {
 // By default, images are stacked left-to-right. Set topToBottom to true to
 // stack them top-to-bottom.
 func (mw *MagickWand) AppendImages(topToBottom bool) *MagickWand {
-	return &MagickWand{C.MagickAppendImages(mw.mw, b2i(topToBottom))}
+	return newMagickWand(C.MagickAppendImages(mw.mw, b2i(topToBottom)))
 }
 
 // Extracts the 'mean' from the image and adjust the image to try make set
@@ -342,7 +342,7 @@ func (mw *MagickWand) ClutImageChannel(channel ChannelType, clut *MagickWand) er
 // is the same size as the first and composited with the next image in the
 // sequence.
 func (mw *MagickWand) CoalesceImages() *MagickWand {
-	return &MagickWand{C.MagickCoalesceImages(mw.mw)}
+	return newMagickWand(C.MagickCoalesceImages(mw.mw))
 }
 
 // Accepts a lightweight Color Correction Collection (CCC) file which solely
@@ -392,7 +392,7 @@ func (mw *MagickWand) ColorMatrixImage(colorMatrix *KernelInfo) error {
 // specified hannels of the combined image. The typical ordering would be
 // image 1 => Red, 2 => Green, 3 => Blue, etc.
 func (mw *MagickWand) CombineImages(channel ChannelType) *MagickWand {
-	return &MagickWand{C.MagickCombineImages(mw.mw, C.ChannelType(channel))}
+	return newMagickWand(C.MagickCombineImages(mw.mw, C.ChannelType(channel)))
 }
 
 // Adds a comment to your image
@@ -407,14 +407,14 @@ func (mw *MagickWand) CommentImage(comment string) error {
 // and returns the difference image
 func (mw *MagickWand) CompareImageChannels(reference *MagickWand, channel ChannelType, metric MetricType) (wand *MagickWand, distortion float64) {
 	cmw := C.MagickCompareImageChannels(mw.mw, reference.mw, C.ChannelType(channel), C.MetricType(metric), (*C.double)(&distortion))
-	wand = &MagickWand{cmw}
+	wand = newMagickWand(cmw)
 	return
 }
 
 // Compares each image with the next in a sequence and returns the maximum
 // bounding region of any pixel differences it discovers.
 func (mw *MagickWand) CompareImageLayers(method ImageLayerMethod) *MagickWand {
-	return &MagickWand{C.MagickCompareImageLayers(mw.mw, C.ImageLayerMethod(method))}
+	return newMagickWand(C.MagickCompareImageLayers(mw.mw, C.ImageLayerMethod(method)))
 }
 
 // CompareImages() compares an image to a reconstructed image and returns the
@@ -422,7 +422,7 @@ func (mw *MagickWand) CompareImageLayers(method ImageLayerMethod) *MagickWand {
 // distortion between the images
 func (mw *MagickWand) CompareImages(reference *MagickWand, metric MetricType) (wand *MagickWand, distortion float64) {
 	cmw := C.MagickCompareImages(mw.mw, reference.mw, C.MetricType(metric), (*C.double)(&distortion))
-	wand = &MagickWand{cmw}
+	wand = newMagickWand(cmw)
 	return
 }
 
@@ -583,7 +583,7 @@ func (mw *MagickWand) DecipherImage(passphrase string) error {
 // Compares each image with the next in a sequence and returns the maximum
 // bouding region of any pixel differences it discovers.
 func (mw *MagickWand) DeconstructImages() *MagickWand {
-	return &MagickWand{C.MagickDeconstructImages(mw.mw)}
+	return newMagickWand(C.MagickDeconstructImages(mw.mw))
 }
 
 // Removes skew from the image. Skew is an artifact that occurs in scanned
@@ -959,7 +959,7 @@ func (mw *MagickWand) FunctionImageChannel(channel ChannelType, function MagickF
 func (mw *MagickWand) FxImage(expression string) (fxmw *MagickWand, err error) {
 	csexpression := C.CString(expression)
 	defer C.free(unsafe.Pointer(csexpression))
-	fxmw = &MagickWand{C.MagickFxImage(mw.mw, csexpression)}
+	fxmw = newMagickWand(C.MagickFxImage(mw.mw, csexpression))
 	err = mw.GetLastError()
 	return
 }
@@ -968,7 +968,8 @@ func (mw *MagickWand) FxImage(expression string) (fxmw *MagickWand, err error) {
 func (mw *MagickWand) FxImageChannel(channel ChannelType, expression string) *MagickWand {
 	csexpression := C.CString(expression)
 	defer C.free(unsafe.Pointer(csexpression))
-	return &MagickWand{C.MagickFxImageChannel(mw.mw, C.ChannelType(channel), csexpression)}
+
+	return newMagickWand(C.MagickFxImageChannel(mw.mw, C.ChannelType(channel), csexpression))
 }
 
 // Gamma-corrects an image. The same image viewed on different devices will
@@ -1023,7 +1024,7 @@ func (mw *MagickWand) GaussianBlurImageChannel(channel ChannelType, radius, sigm
 
 // Gets the image at the current image index.
 func (mw *MagickWand) GetImage() *MagickWand {
-	return &MagickWand{C.MagickGetImage(mw.mw)}
+	return newMagickWand(C.MagickGetImage(mw.mw))
 }
 
 // Returns false if the image alpha channel is not activated. That is, the
@@ -1034,7 +1035,7 @@ func (mw *MagickWand) GetImageAlphaChannel() bool {
 
 // Gets the image clip mask at the current image index.
 func (mw *MagickWand) GetImageClipMask() *MagickWand {
-	return &MagickWand{C.MagickGetImageClipMask(mw.mw)}
+	return newMagickWand(C.MagickGetImageClipMask(mw.mw))
 }
 
 // Returns the image background color.
@@ -1298,7 +1299,7 @@ func (mw *MagickWand) GetImageHistogram() (numberColors uint, pws []PixelWand) {
 		if *p == nil {
 			break
 		}
-		pws = append(pws, PixelWand{*p})
+		pws = append(pws, *newPixelWand(*p))
 		q += unsafe.Sizeof(q)
 	}
 	numberColors = uint(cnc)
@@ -1371,7 +1372,7 @@ func (mw *MagickWand) GetImageRedPrimary() (x, y float64, err error) {
 
 // Extracts a region of the image and returns it as a a new wand.
 func (mw *MagickWand) GetImageRegion(width uint, height uint, x int, y int) *MagickWand {
-	return &MagickWand{C.MagickGetImageRegion(mw.mw, C.size_t(width), C.size_t(height), C.ssize_t(x), C.ssize_t(y))}
+	return newMagickWand(C.MagickGetImageRegion(mw.mw, C.size_t(width), C.size_t(height), C.ssize_t(x), C.ssize_t(y)))
 }
 
 // Gets the image rendering intent.
@@ -1677,7 +1678,7 @@ func (mw *MagickWand) MagnifyImage() error {
 // first image, enlarging left and right edges to contain all images. Images
 // with negative offsets will be clipped.
 func (mw *MagickWand) MergeImageLayers(method ImageLayerMethod) *MagickWand {
-	return &MagickWand{C.MagickMergeImageLayers(mw.mw, C.ImageLayerMethod(method))}
+	return newMagickWand(C.MagickMergeImageLayers(mw.mw, C.ImageLayerMethod(method)))
 }
 
 // This is a convenience method that scales an image proportionally to
@@ -1730,7 +1731,8 @@ func (mw *MagickWand) MontageImage(dw *DrawingWand, tileGeo string, thumbGeo str
 	defer C.free(unsafe.Pointer(csthumb))
 	csframe := C.CString(frame)
 	defer C.free(unsafe.Pointer(csframe))
-	return &MagickWand{C.MagickMontageImage(mw.mw, dw.dw, cstile, csthumb, C.MontageMode(mode), csframe)}
+
+	return newMagickWand(C.MagickMontageImage(mw.mw, dw.dw, cstile, csthumb, C.MontageMode(mode), csframe))
 }
 
 // Method morphs a set of images. Both the image pixels and size are linearly
@@ -1739,8 +1741,7 @@ func (mw *MagickWand) MontageImage(dw *DrawingWand, tileGeo string, thumbGeo str
 //
 // numFrames: the number of in-between images to generate.
 func (mw *MagickWand) MorphImages(numFrames uint) *MagickWand {
-	//
-	return &MagickWand{C.MagickMorphImages(mw.mw, C.size_t(numFrames))}
+	return newMagickWand(C.MagickMorphImages(mw.mw, C.size_t(numFrames)))
 }
 
 // Applies a user supplied kernel to the image according to the given mophology
@@ -1924,7 +1925,7 @@ func (mw *MagickWand) OpaquePaintImageChannel(channel ChannelType, target, fill 
 // sequence. From this it attempts to select the smallest cropped image to
 // replace each frame, while preserving the results of the animation.
 func (mw *MagickWand) OptimizeImageLayers() *MagickWand {
-	return &MagickWand{C.MagickOptimizeImageLayers(mw.mw)}
+	return newMagickWand(C.MagickOptimizeImageLayers(mw.mw))
 }
 
 // Unsupported in ImageMagick 6.7.7
@@ -2037,7 +2038,7 @@ func (mw *MagickWand) PosterizeImage(levels uint, dither bool) error {
 // operation applied at varying strengths. This helpful to quickly pin-point
 // an appropriate parameter for an image processing operation.
 func (mw *MagickWand) PreviewImages(preview PreviewType) *MagickWand {
-	return &MagickWand{C.MagickPreviewImages(mw.mw, C.PreviewType(preview))}
+	return newMagickWand(C.MagickPreviewImages(mw.mw, C.PreviewType(preview)))
 }
 
 // Sets the previous image in the wand as the current image. It is typically
@@ -2783,7 +2784,7 @@ func (mw *MagickWand) SigmoidalContrastImageChannel(channel ChannelType, sharpen
 func (mw *MagickWand) SimilarityImage(reference *MagickWand) (offset *RectangleInfo, similarity float64, area *MagickWand) {
 	var rectInfo C.RectangleInfo
 	mwarea := C.MagickSimilarityImage(mw.mw, reference.mw, &rectInfo, (*C.double)(&similarity))
-	return &RectangleInfo{&rectInfo}, similarity, &MagickWand{mwarea}
+	return &RectangleInfo{&rectInfo}, similarity, newMagickWand(mwarea)
 }
 
 // Simulates a pencil sketch. We convolve the image with a Gaussian operator
@@ -2813,7 +2814,7 @@ func (mw *MagickWand) SketchImage(radius, sigma, angle float64) error {
 // offset: minimum distance in pixels between images.
 //
 func (mw *MagickWand) SmushImages(stack bool, offset int) *MagickWand {
-	return &MagickWand{C.MagickSmushImages(mw.mw, b2i(stack), C.ssize_t(offset))}
+	return newMagickWand(C.MagickSmushImages(mw.mw, b2i(stack), C.ssize_t(offset)))
 }
 
 // Applies a special effect to the image, similar to the effect achieved in a
@@ -2914,13 +2915,13 @@ func (mw *MagickWand) StatisticImageChannel(channel ChannelType, stype Statistic
 // offset: start hiding at this offset into the image.
 //
 func (mw *MagickWand) SteganoImage(watermark *MagickWand, offset int) *MagickWand {
-	return &MagickWand{C.MagickSteganoImage(mw.mw, watermark.mw, C.ssize_t(offset))}
+	return newMagickWand(C.MagickSteganoImage(mw.mw, watermark.mw, C.ssize_t(offset)))
 }
 
 // Composites two images and produces a single image that is the composite of
 // a left and right image of a stereo pair.
 func (mw *MagickWand) StereoImage(offset *MagickWand) *MagickWand {
-	return &MagickWand{C.MagickStereoImage(mw.mw, offset.mw)}
+	return newMagickWand(C.MagickStereoImage(mw.mw, offset.mw))
 }
 
 // Strips an image of all profiles and comments.
@@ -2942,7 +2943,7 @@ func (mw *MagickWand) SwirlImage(degrees float64) error {
 
 // Repeatedly tiles the texture image across and down the image canvas.
 func (mw *MagickWand) TextureImage(texture *MagickWand) *MagickWand {
-	return &MagickWand{C.MagickTextureImage(mw.mw, texture.mw)}
+	return newMagickWand(C.MagickTextureImage(mw.mw, texture.mw))
 }
 
 // Changes the value of individual pixels based on the intensity of each pixel
@@ -2997,7 +2998,8 @@ func (mw *MagickWand) TransformImage(crop string, geometry string) *MagickWand {
 	cscrop, csgeo := C.CString(crop), C.CString(geometry)
 	defer C.free(unsafe.Pointer(cscrop))
 	defer C.free(unsafe.Pointer(csgeo))
-	return &MagickWand{C.MagickTransformImage(mw.mw, cscrop, csgeo)}
+
+	return newMagickWand(C.MagickTransformImage(mw.mw, cscrop, csgeo))
 }
 
 // Transform the image colorspace, setting the images colorspace while

--- a/imagick/magick_wand_prop.go
+++ b/imagick/magick_wand_prop.go
@@ -45,7 +45,7 @@ func (mw *MagickWand) GetAntialias() bool {
 
 // Returns the wand background color
 func (mw *MagickWand) GetBackgroundColor() *PixelWand {
-	return &PixelWand{C.MagickGetBackgroundColor(mw.mw)}
+	return newPixelWand(C.MagickGetBackgroundColor(mw.mw))
 }
 
 // Returns the wand colorspace type

--- a/imagick/magick_wand_test.go
+++ b/imagick/magick_wand_test.go
@@ -5,21 +5,30 @@
 package imagick
 
 import (
+	"fmt"
 	"reflect"
+	"runtime"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 var (
 	mw *MagickWand
 )
 
-func Init() {
+func init() {
 	Initialize()
 }
 
 func TestNewMagickWand(t *testing.T) {
+	Initialize()
+	defer func(t *testing.T) {
+		checkGC(t)
+	}(t)
+	defer Terminate()
+
 	mw := NewMagickWand()
-	defer mw.Destroy()
 
 	if !mw.IsVerified() {
 		t.Fatal("MagickWand not verified")
@@ -27,19 +36,34 @@ func TestNewMagickWand(t *testing.T) {
 }
 
 func TestCloningAndDestroying(t *testing.T) {
+	Initialize()
+	defer func(t *testing.T) {
+		checkGC(t)
+	}(t)
+	defer Terminate()
+
 	mw := NewMagickWand()
-	defer mw.Destroy()
 	clone := mw.Clone()
 	if !clone.IsVerified() {
 		t.Fatal("Unsuccessful clone")
 	}
-	clone.Destroy()
-	if clone.IsVerified() || !mw.IsVerified() {
+
+	clone = nil
+	runtime.GC()
+	time.Sleep(100 * time.Millisecond)
+
+	if !mw.IsVerified() {
 		t.Fatal("MagickWand not properly destroyed")
 	}
 }
 
 func TestQueryConfigureOptions(t *testing.T) {
+	Initialize()
+	defer func(t *testing.T) {
+		checkGC(t)
+	}(t)
+	defer Terminate()
+
 	opts := mw.QueryConfigureOptions("*")
 	if len(opts) == 0 {
 		t.Fatal("QueryConfigureOptions returned an empty array")
@@ -50,6 +74,12 @@ func TestQueryConfigureOptions(t *testing.T) {
 }
 
 func TestNonExistingConfigureOption(t *testing.T) {
+	Initialize()
+	defer func(t *testing.T) {
+		checkGC(t)
+	}(t)
+	defer Terminate()
+
 	_, err := mw.QueryConfigureOption("4321foobaramps1234")
 	if err == nil {
 		t.Fatal("Missing error when trying to get non-existing configure option")
@@ -57,6 +87,12 @@ func TestNonExistingConfigureOption(t *testing.T) {
 }
 
 func TestQueryFonts(t *testing.T) {
+	Initialize()
+	defer func(t *testing.T) {
+		checkGC(t)
+	}(t)
+	defer Terminate()
+
 	fonts := mw.QueryFonts("*")
 	if len(fonts) == 0 {
 		t.Fatal("ImageMagick have not identified a single font in this system")
@@ -64,6 +100,12 @@ func TestQueryFonts(t *testing.T) {
 }
 
 func TestQueryFormats(t *testing.T) {
+	Initialize()
+	defer func(t *testing.T) {
+		checkGC(t)
+	}(t)
+	defer Terminate()
+
 	formats := mw.QueryFormats("*")
 	if len(formats) == 0 {
 		t.Fatal("ImageMagick have not identified a single image format in this system")
@@ -71,9 +113,13 @@ func TestQueryFormats(t *testing.T) {
 }
 
 func TestDeleteImageArtifact(t *testing.T) {
-	mw := NewMagickWand()
-	defer mw.Destroy()
+	Initialize()
+	defer func(t *testing.T) {
+		checkGC(t)
+	}(t)
+	defer Terminate()
 
+	mw := NewMagickWand()
 	mw.ReadImage(`logo:`)
 
 	if err := mw.DeleteImageArtifact("*"); err != nil {
@@ -82,8 +128,13 @@ func TestDeleteImageArtifact(t *testing.T) {
 }
 
 func TestReadImageBlob(t *testing.T) {
+	Initialize()
+	defer func(t *testing.T) {
+		checkGC(t)
+	}(t)
+	defer Terminate()
+
 	mw := NewMagickWand()
-	defer mw.Destroy()
 
 	// Read an invalid blob
 	blob := []byte{}
@@ -102,8 +153,12 @@ func TestReadImageBlob(t *testing.T) {
 
 func TestGetImageFloats(t *testing.T) {
 	Initialize()
+	defer func(t *testing.T) {
+		checkGC(t)
+	}(t)
+	defer Terminate()
+
 	mw := NewMagickWand()
-	defer mw.Destroy()
 
 	var err error
 	if err = mw.ReadImage(`logo:`); err != nil {
@@ -158,6 +213,12 @@ func TestGetImageFloats(t *testing.T) {
 }
 
 func TestGetQuantumDepth(t *testing.T) {
+	Initialize()
+	defer func(t *testing.T) {
+		checkGC(t)
+	}(t)
+	defer Terminate()
+
 	name, depth := GetQuantumDepth()
 	if name == "" {
 		t.Fatal("Depth name returned was an empty string")
@@ -168,6 +229,12 @@ func TestGetQuantumDepth(t *testing.T) {
 }
 
 func TestGetQuantumRange(t *testing.T) {
+	Initialize()
+	defer func(t *testing.T) {
+		checkGC(t)
+	}(t)
+	defer Terminate()
+
 	name, r := GetQuantumRange()
 	if name == "" {
 		t.Fatal("Depth name returned was an empty string")
@@ -177,9 +244,23 @@ func TestGetQuantumRange(t *testing.T) {
 	}
 }
 
+func checkGC(t *testing.T) {
+	if !isImageMagickCleaned() {
+		t.Fatal("Some ImageMagick objects are not destroyed", getObjectCountersString())
+	}
+}
+
+func getObjectCountersString() string {
+	str := fmt.Sprintf("magickWandCounter %d\n", atomic.LoadInt64(&magickWandCounter))
+	str += fmt.Sprintf("drawingWandCounter %d\n", atomic.LoadInt64(&drawingWandCounter))
+	str += fmt.Sprintf("pixelIteratorCounter %d\n", atomic.LoadInt64(&pixelIteratorCounter))
+	str += fmt.Sprintf("pixelWandCounter %d\n", atomic.LoadInt64(&pixelWandCounter))
+
+	return str
+}
+
 func BenchmarkExportImagePixels(b *testing.B) {
 	wand := NewMagickWand()
-	defer wand.Destroy()
 
 	wand.ReadImage("logo:")
 	wand.ScaleImage(1024, 1024)
@@ -203,7 +284,6 @@ func BenchmarkExportImagePixels(b *testing.B) {
 
 func BenchmarkImportImagePixels(b *testing.B) {
 	wand := NewMagickWand()
-	defer wand.Destroy()
 
 	wand.ReadImage("logo:")
 	wand.ScaleImage(1024, 1024)

--- a/imagick/pixel_iterator.go
+++ b/imagick/pixel_iterator.go
@@ -20,8 +20,8 @@ import (
 )
 
 type PixelIterator struct {
-	pi *C.PixelIterator
-	sync.Once
+	pi   *C.PixelIterator
+	init sync.Once
 }
 
 func newPixelIterator(cpi *C.PixelIterator) *PixelIterator {
@@ -65,7 +65,7 @@ func (pi *PixelIterator) Destroy() {
 		return
 	}
 
-	pi.Do(func() {
+	pi.init.Do(func() {
 		pi.pi = C.DestroyPixelIterator(pi.pi)
 		relinquishMemory(unsafe.Pointer(pi.pi))
 		pi.pi = nil

--- a/imagick/pixel_iterator.go
+++ b/imagick/pixel_iterator.go
@@ -12,10 +12,24 @@ static PixelWand* get_pw_at(PixelWand** pws, size_t pos) {
 }
 */
 import "C"
-import "unsafe"
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+)
 
 type PixelIterator struct {
 	pi *C.PixelIterator
+	sync.Once
+}
+
+func newPixelIterator(cpi *C.PixelIterator) *PixelIterator {
+	pi := &PixelIterator{pi: cpi}
+	runtime.SetFinalizer(pi, Destroy)
+	pi.IncreaseCount()
+
+	return pi
 }
 
 // Returns a new pixel iterator
@@ -23,7 +37,7 @@ type PixelIterator struct {
 // mw: the magick wand to iterate on
 //
 func (mw *MagickWand) NewPixelIterator() *PixelIterator {
-	return &PixelIterator{C.NewPixelIterator(mw.mw)}
+	return newPixelIterator(C.NewPixelIterator(mw.mw))
 }
 
 // Returns a new pixel iterator
@@ -32,7 +46,7 @@ func (mw *MagickWand) NewPixelIterator() *PixelIterator {
 // x, y, cols, rows: there values define the perimeter of a region of pixels
 //
 func (mw *MagickWand) NewPixelRegionIterator(x, y int, width, height uint) *PixelIterator {
-	return &PixelIterator{C.NewPixelRegionIterator(mw.mw, C.ssize_t(x), C.ssize_t(y), C.size_t(width), C.size_t(height))}
+	return newPixelIterator(C.NewPixelRegionIterator(mw.mw, C.ssize_t(x), C.ssize_t(y), C.size_t(width), C.size_t(height)))
 }
 
 // Clear resources associated with a PixelIterator.
@@ -42,7 +56,7 @@ func (pi *PixelIterator) Clear() {
 
 // Makes an exact copy of the specified iterator.
 func (pi *PixelIterator) Clone() *PixelIterator {
-	return &PixelIterator{C.ClonePixelIterator(pi.pi)}
+	return newPixelIterator(C.ClonePixelIterator(pi.pi))
 }
 
 // Deallocates resources associated with a PixelIterator.
@@ -50,9 +64,14 @@ func (pi *PixelIterator) Destroy() {
 	if pi.pi == nil {
 		return
 	}
-	pi.pi = C.DestroyPixelIterator(pi.pi)
-	relinquishMemory(unsafe.Pointer(pi.pi))
-	pi.pi = nil
+
+	pi.Do(func() {
+		pi.pi = C.DestroyPixelIterator(pi.pi)
+		relinquishMemory(unsafe.Pointer(pi.pi))
+		pi.pi = nil
+
+		pi.DecreaseCount()
+	})
 }
 
 // Returns true if the iterator is verified as a pixel iterator.
@@ -61,6 +80,18 @@ func (pi *PixelIterator) IsVerified() bool {
 		return false
 	}
 	return 1 == C.IsPixelIterator(pi.pi)
+}
+
+// Increase PixelIterator ref counter and set according "can`t be terminated status"
+func (pi *PixelIterator) IncreaseCount() {
+	atomic.AddInt64(&pixelIteratorCounter, int64(1))
+	unsetCanTerminate()
+}
+
+// Decrease DrawingWand ref counter and set according "can be terminated status"
+func (pi *PixelIterator) DecreaseCount() {
+	atomic.AddInt64(&pixelIteratorCounter, int64(-1))
+	setCanTerminate()
 }
 
 // Returns the current row as an array of pixel wands from the pixel iterator.
@@ -72,7 +103,7 @@ func (pi *PixelIterator) GetCurrentIteratorRow() (pws []*PixelWand) {
 	}
 	for i := 0; i < int(num); i++ {
 		cpw := C.get_pw_at(pp, C.size_t(i))
-		pws = append(pws, &PixelWand{cpw})
+		pws = append(pws, newPixelWand(cpw))
 	}
 	return
 }
@@ -91,7 +122,7 @@ func (pi *PixelIterator) GetNextIteratorRow() (pws []*PixelWand) {
 	}
 	for i := 0; i < int(num); i++ {
 		cpw := C.get_pw_at(pp, C.size_t(i))
-		pws = append(pws, &PixelWand{cpw})
+		pws = append(pws, newPixelWand(cpw))
 	}
 	return
 }
@@ -105,7 +136,7 @@ func (pi *PixelIterator) GetPreviousIteratorRow() (pws []*PixelWand) {
 	}
 	for i := 0; i < int(num); i++ {
 		cpw := C.get_pw_at(pp, C.size_t(i))
-		pws = append(pws, &PixelWand{cpw})
+		pws = append(pws, newPixelWand(cpw))
 	}
 	return
 }

--- a/imagick/pixel_wand.go
+++ b/imagick/pixel_wand.go
@@ -10,16 +10,29 @@ package imagick
 import "C"
 
 import (
+	"runtime"
+	"sync"
+	"sync/atomic"
 	"unsafe"
 )
 
 type PixelWand struct {
 	pw *C.PixelWand
+	sync.Once
+}
+
+// Returns a new pixel wand
+func newPixelWand(cpw *C.PixelWand) *PixelWand {
+	pw := &PixelWand{pw: cpw}
+	runtime.SetFinalizer(pw, Destroy)
+	pw.IncreaseCount()
+
+	return pw
 }
 
 // Returns a new pixel wand
 func NewPixelWand() *PixelWand {
-	return &PixelWand{C.NewPixelWand()}
+	return newPixelWand(C.NewPixelWand())
 }
 
 // Clears resources associated with the wand
@@ -29,7 +42,7 @@ func (pw *PixelWand) Clear() {
 
 // Makes an exact copy of the wand
 func (pw *PixelWand) Clone() *PixelWand {
-	return &PixelWand{C.ClonePixelWand(pw.pw)}
+	return newPixelWand(C.ClonePixelWand(pw.pw))
 }
 
 // Deallocates resources associated with a pixel wand
@@ -37,9 +50,14 @@ func (pw *PixelWand) Destroy() {
 	if pw.pw == nil {
 		return
 	}
-	pw.pw = C.DestroyPixelWand(pw.pw)
-	relinquishMemory(unsafe.Pointer(pw.pw))
-	pw.pw = nil
+
+	pw.Do(func() {
+		pw.pw = C.DestroyPixelWand(pw.pw)
+		relinquishMemory(unsafe.Pointer(pw.pw))
+		pw.pw = nil
+
+		pw.DecreaseCount()
+	})
 }
 
 // Returns true if the distance between two colors is less than the specified distance
@@ -53,6 +71,18 @@ func (pw *PixelWand) IsVerified() bool {
 		return 1 == C.int(C.IsPixelWand(pw.pw))
 	}
 	return false
+}
+
+// Increase PixelWand ref counter and set according "can`t be terminated status"
+func (pw *PixelWand) IncreaseCount() {
+	atomic.AddInt64(&pixelWandCounter, int64(1))
+	unsetCanTerminate()
+}
+
+// Decrease PixelWand ref counter and set according "can be terminated status"
+func (pw *PixelWand) DecreaseCount() {
+	atomic.AddInt64(&pixelWandCounter, int64(-1))
+	setCanTerminate()
 }
 
 // Returns the normalized alpha color of the pixel wand

--- a/imagick/pixel_wand.go
+++ b/imagick/pixel_wand.go
@@ -17,8 +17,8 @@ import (
 )
 
 type PixelWand struct {
-	pw *C.PixelWand
-	sync.Once
+	pw   *C.PixelWand
+	init sync.Once
 }
 
 // Returns a new pixel wand
@@ -51,7 +51,7 @@ func (pw *PixelWand) Destroy() {
 		return
 	}
 
-	pw.Do(func() {
+	pw.init.Do(func() {
 		pw.pw = C.DestroyPixelWand(pw.pw)
 		relinquishMemory(unsafe.Pointer(pw.pw))
 		pw.pw = nil

--- a/imagick/types/clearer.go
+++ b/imagick/types/clearer.go
@@ -1,0 +1,5 @@
+package types
+
+type Clearer interface {
+	Clear()
+}

--- a/imagick/types/decreaser.go
+++ b/imagick/types/decreaser.go
@@ -1,0 +1,5 @@
+package types
+
+type Decreaser interface {
+	DecreaseCount()
+}

--- a/imagick/types/destroyer.go
+++ b/imagick/types/destroyer.go
@@ -1,0 +1,6 @@
+package types
+
+// Destroyer represents destroyable types which require manual release of resources
+type Destroyer interface {
+	Destroy()
+}

--- a/imagick/types/imagick.go
+++ b/imagick/types/imagick.go
@@ -1,0 +1,10 @@
+package types
+
+// ImageMagick objects common interface
+type IMagick interface {
+	Clearer
+	Destroyer
+	Verifier
+	Increaser
+	Decreaser
+}

--- a/imagick/types/increaser.go
+++ b/imagick/types/increaser.go
@@ -1,0 +1,5 @@
+package types
+
+type Increaser interface {
+	IncreaseCount()
+}

--- a/imagick/types/verifier.go
+++ b/imagick/types/verifier.go
@@ -1,0 +1,6 @@
+package types
+
+// Returns true if the object is a verified C object
+type Verifier interface {
+	IsVerified() bool
+}


### PR DESCRIPTION
Replaces Pull Request #62, with latest merges, canonical path fixes, and hides the `sync.Once` embedding.