### PR TITLE
Fixes #114 -  Add missing image methods

### DIFF
--- a/imagick/magick_wand_image.go
+++ b/imagick/magick_wand_image.go
@@ -1961,6 +1961,15 @@ func (mw *MagickWand) SetImageBorderColor(border *PixelWand) error {
 	return mw.getLastErrorIfFailed(ok)
 }
 
+// SetImageChannelMask sets image channel mask, and returns
+// the previous channel type setting.
+// Setting the channel mask impacts the effect of image operations,
+// to limit the operation to the given channel.
+func (mw *MagickWand) SetImageChannelMask(channel ChannelType) ChannelType {
+	prevChannel := C.MagickSetImageChannelMask(mw.mw, C.ChannelType(channel))
+	return ChannelType(prevChannel)
+}
+
 // Set the entire wand canvas to the specified color.
 func (mw *MagickWand) SetImageColor(color *PixelWand) error {
 	ok := C.MagickSetImageColor(mw.mw, color.pw)

--- a/imagick/magick_wand_image.go
+++ b/imagick/magick_wand_image.go
@@ -847,6 +847,12 @@ func (mw *MagickWand) GetImage() *MagickWand {
 	return newMagickWand(C.MagickGetImage(mw.mw))
 }
 
+// GetImageAlphaChannel returns MagickFalse if the image alpha channel is not
+// activated. That is, the image is RGB rather than RGBA or CMYK rather than CMYKA.
+func (mw *MagickWand) GetImageAlphaChannel() bool {
+	return 1 == C.MagickGetImageAlphaChannel(mw.mw)
+}
+
 // Returns the image background color.
 func (mw *MagickWand) GetImageBackgroundColor() (bgColor *PixelWand, err error) {
 	cbgcolor := NewPixelWand()

--- a/imagick/magick_wand_test.go
+++ b/imagick/magick_wand_test.go
@@ -142,6 +142,21 @@ func TestImageAlpha(t *testing.T) {
 	}
 }
 
+func TestImageChannelMask(t *testing.T) {
+	mw := NewMagickWand()
+	mw.ReadImage(`logo:`)
+
+	channel := mw.SetImageChannelMask(CHANNEL_ALPHA)
+	if channel != CHANNELS_ALL {
+		t.Fatalf("Expected CHANNELS_ALL (%v), got %v", CHANNELS_ALL, channel)
+	}
+
+	channel = mw.SetImageChannelMask(CHANNELS_ALL)
+	if channel != CHANNEL_ALPHA {
+		t.Fatalf("Expected CHANNEL_ALPHA (%v), got %v", CHANNEL_ALPHA, channel)
+	}
+}
+
 func TestReadImageBlob(t *testing.T) {
 	Initialize()
 	defer func(t *testing.T) {

--- a/imagick/magick_wand_test.go
+++ b/imagick/magick_wand_test.go
@@ -127,6 +127,21 @@ func TestDeleteImageArtifact(t *testing.T) {
 	}
 }
 
+func TestImageAlpha(t *testing.T) {
+	mw := NewMagickWand()
+	mw.ReadImage(`logo:`)
+
+	if mw.GetImageAlphaChannel() {
+		t.Fatal("Expected image not to have an activated alpha channel")
+	}
+
+	mw.SetImageAlphaChannel(ALPHA_CHANNEL_ACTIVATE)
+
+	if !mw.GetImageAlphaChannel() {
+		t.Fatal("Expected image to have an activated alpha channel")
+	}
+}
+
 func TestReadImageBlob(t *testing.T) {
 	Initialize()
 	defer func(t *testing.T) {


### PR DESCRIPTION
Refs #114 

Merge add the following missing image methods:
* `GetImageAlphaChannel()`
* `SetImageChannelMask()`