### PR TITLE
fix(ex-resize): deferred free magick wand call

### DIFF
--- a/examples/resize/main.go
+++ b/examples/resize/main.go
@@ -14,6 +14,7 @@ func main() {
 	var err error
 
 	mw := imagick.NewMagickWand()
+	defer mw.Destroy()
 
 	err = mw.ReadImage("logo:")
 	if err != nil {


### PR DESCRIPTION
Totally new to writing go, so this is a question first before a PR. The main page shows freeing magick wand instances, so is this required in a case like the resize example?