### PR TITLE
Fix dereferencing / free memory issues with GetImageHistogram

### DIFF
--- a/imagick/magick_wand_image.go
+++ b/imagick/magick_wand_image.go
@@ -1363,20 +1363,20 @@ func (mw *MagickWand) GetImageHeight() uint {
 //
 // numberColors: the number of unique colors in the image and the number of
 // pixel wands returned.
-func (mw *MagickWand) GetImageHistogram() (numberColors uint, pws []PixelWand) {
+func (mw *MagickWand) GetImageHistogram() (numberColors uint, pws []*PixelWand) {
 	cnc := C.size_t(0)
 	p := C.MagickGetImageHistogram(mw.mw, &cnc)
 	defer relinquishMemory(unsafe.Pointer(p))
 	q := uintptr(unsafe.Pointer(p))
-	for {
+	numberColors = uint(cnc)
+	for i := 0; i < int(numberColors); i++ {
 		p = (**C.PixelWand)(unsafe.Pointer(q))
 		if *p == nil {
 			break
 		}
-		pws = append(pws, *newPixelWand(*p))
+		pws = append(pws, newPixelWand(*p))
 		q += unsafe.Sizeof(q)
 	}
-	numberColors = uint(cnc)
 	runtime.KeepAlive(mw)
 	return
 }


### PR DESCRIPTION
An issue is that copies of the PixelWand objects are being made (and
returned). This causes C.DestroyPixelWand to be called twice on a
*C.PixelWand leading to a fatal error.

In addition there were occasions where numberColors != len([]PixelWand)
due to checks being simply if the pointer's value was not nil. This
caused a seg-fault when accessing [idx]PixelWand values where
idx >= numberColors, which can commonly happen when doing a for-each
loop.

**This pull could be a breaking change because the signature of GetImageHistogram will be changed**. 

There isn't a way to manually trigger sync.Once to not execute as far as I'm aware of. One way to get around this is to change the use of sync.Once to atomics to ensure one time execution. 

Because the pointer to the uint will be the same, we can use atomic.CompareAndSwap to ensure one time execution, and this will allow us to still create copies and maintain the function signature.

I was unsure of which would be the preferred fix and thought it better to open this for discussion.