### PR TITLE
fix(examples): Get the size of a space again when fontsize changed

### DIFF
--- a/examples/fontmetrics/main.go
+++ b/examples/fontmetrics/main.go
@@ -21,11 +21,11 @@ func draw_setfont(mw *imagick.MagickWand, dw *imagick.DrawingWand, font string, 
 		pw.SetColor(colour)
 		dw.SetFillColor(pw)
 		pw.Destroy()
-		sflag = true
 	}
 
 	if size > 0 {
 		dw.SetFontSize(size)
+		sflag = true
 	}
 
 	// If either the font or the fontsize (or both) have changed


### PR DESCRIPTION
This pr includes two changes in fontmetrics examples.

1. If the font color changed, **do not** get the size of a space again.
2. If the font size changed, get the size of a space again.

Thanks!

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/gographics/imagick/171)
<!-- Reviewable:end -->
