### PR TITLE
add documentation for whitelisting clang command

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,13 @@ Then go get it:
 go get gopkg.in/gographics/imagick.v2/imagick
 ```
 
+Per the security update https://groups.google.com/forum/#!topic/golang-announce/X7N1mvntnoU
+you may need whitelist the -Xpreprocessor flag in your environment.
+
+```
+export CGO_CFLAGS_ALLOW='-Xpreprocessor'
+```
+
 ### Build tags
 
 If you want to specify CGO_CFLAGS/CGO_LDFLAGS manually at build time, such as for building statically or without pkg-config, you can use the "no_pkgconfig" build tag:

--- a/env.sh
+++ b/env.sh
@@ -1,2 +1,3 @@
 export CGO_CFLAGS="-I`pkg-config --cflags MagickWand`"
 export CGO_LDFLAGS="-I`pkg-config --libs MagickWand`"
+export CGO_CFLAGS_ALLOW='-Xpreprocessor'


### PR DESCRIPTION
On OSX High Sierra with go version go1.11.1 darwin/amd64 I had to whitelist the -Xpreprocessor command in order to get go build to work as well as intellisense with VSCode.

Ref: https://groups.google.com/forum/#!topic/golang-announce/X7N1mvntnoU