### PR TITLE
Update Comment for "SetImageProperty" regarding persisting set properties

### DIFF
--- a/imagick/magick_wand_prop.go
+++ b/imagick/magick_wand_prop.go
@@ -412,9 +412,8 @@ func (mw *MagickWand) SetImageProfile(name string, profile []byte) error {
 }
 
 // Associates a property with an image.
-// Note: no tags except "comment" are persisted, during the use of the instance
-// all tags are accessible, should the data be written(to a file, as btye slice...) and re read,
-//all edited tags excluding "comment" will NOT be present anymore.
+// Note: Which properties are persisted(file write, byte slice) depends on the writer for the used fle format respectively.
+// Refer to the ImageMagick documention for more specific information.
 func (mw *MagickWand) SetImageProperty(property, value string) error {
 	csproperty := C.CString(property)
 	defer C.free(unsafe.Pointer(csproperty))

--- a/imagick/magick_wand_prop.go
+++ b/imagick/magick_wand_prop.go
@@ -412,6 +412,9 @@ func (mw *MagickWand) SetImageProfile(name string, profile []byte) error {
 }
 
 // Associates a property with an image.
+// Note: no tags except "comment" are persisted, during the use of the instance
+// all tags are accessible, should the data be written(to a file, as btye slice...) and re read,
+//all edited tags excluding "comment" will NOT be present anymore.
 func (mw *MagickWand) SetImageProperty(property, value string) error {
 	csproperty := C.CString(property)
 	defer C.free(unsafe.Pointer(csproperty))

--- a/imagick/magick_wand_prop.go
+++ b/imagick/magick_wand_prop.go
@@ -412,8 +412,8 @@ func (mw *MagickWand) SetImageProfile(name string, profile []byte) error {
 }
 
 // Associates a property with an image.
-// Note: Which properties are persisted(file write, byte slice) depends on the writer for the used fle format respectively.
-// Refer to the ImageMagick documention for more specific information.
+// Note: Which properties are persisted(file write, byte slice) depends on the writer for the used file format respectively.
+// Refer to the ImageMagick documention and source for more specific information.
 func (mw *MagickWand) SetImageProperty(property, value string) error {
 	csproperty := C.CString(property)
 	defer C.free(unsafe.Pointer(csproperty))


### PR DESCRIPTION
I was stuck on wondering why changes are not being persisted for the last couple hours.
When i randomly stumbled across a comment in the PHP doc for the php wrapper api.
See: https://www.php.net/manual/en/imagick.setimageproperty.php#123346
Where it was finally revealed to me.
Related issues: https://github.com/ImageMagick/ImageMagick/issues/55
https://github.com/Imagick/imagick/issues/124