### PR TITLE
Move SetResourceLimit to package level

### DIFF
--- a/imagick/magick_version.go
+++ b/imagick/magick_version.go
@@ -68,3 +68,9 @@ func GetVersion() (version string, nversion uint) {
 	nversion = uint(cnver)
 	return
 }
+
+// Specify resource limit at package level.
+func SetResourceLimit(rtype ResourceType, limit uint64) bool {
+	ok := C.MagickSetResourceLimit(C.ResourceType(rtype), C.MagickSizeType(limit))
+	return C.int(ok) == 1
+}

--- a/imagick/magick_wand_prop.go
+++ b/imagick/magick_wand_prop.go
@@ -468,12 +468,6 @@ func (mw *MagickWand) SetPointsize(pointSize float64) error {
 	return mw.getLastErrorIfFailed(ok)
 }
 
-// SetResourceLimit Sets the limit for a particular resource in megabytes.
-func (mw *MagickWand) SetResourceLimit(rtype ResourceType, limit int64) error {
-	ok := C.MagickSetResourceLimit(C.ResourceType(rtype), C.MagickSizeType(limit))
-	return mw.getLastErrorIfFailed(ok)
-}
-
 // SetResolution Sets the image resolution.
 func (mw *MagickWand) SetResolution(xRes, yRes float64) error {
 	ok := C.MagickSetResolution(mw.mw, C.double(xRes), C.double(yRes))


### PR DESCRIPTION
Move the `SetResourceLimit()` function from the `MagickWand` type to the package level.

I am not sure what your process is to merge changes from the master branch but this does the same as PR #139 but for the ImageMagick 7.