### PR TITLE
Add im7 core GetDelegates() and GetFeatures()

### DIFF
--- a/imagick/magick_version.go
+++ b/imagick/magick_version.go
@@ -5,10 +5,25 @@
 package imagick
 
 /*
+#include <MagickCore/MagickCore.h>
 #include <MagickWand/MagickWand.h>
 */
 import "C"
 import "unsafe"
+
+// Returns the ImageMagick delegates as a string constant.
+func GetDelegates() (delegates string) {
+	csdelegates := C.GetMagickDelegates()
+
+	return C.GoString(csdelegates)
+}
+
+// Returns the ImageMagick features as a string constant.
+func GetFeatures() (features string) {
+	csfeatures := C.GetMagickFeatures()
+
+	return C.GoString(csfeatures)
+}
 
 // Returns the ImageMagick API copyright as a string constant.
 func GetCopyright() string {

--- a/imagick/magick_version.go
+++ b/imagick/magick_version.go
@@ -12,17 +12,15 @@ import "C"
 import "unsafe"
 
 // Returns the ImageMagick delegates as a string constant.
-func GetDelegates() (delegates string) {
-	csdelegates := C.GetMagickDelegates()
-
-	return C.GoString(csdelegates)
+func GetDelegates() string {
+	cstr := C.GetMagickDelegates()
+	return C.GoString(cstr)
 }
 
 // Returns the ImageMagick features as a string constant.
-func GetFeatures() (features string) {
-	csfeatures := C.GetMagickFeatures()
-
-	return C.GoString(csfeatures)
+func GetFeatures() string {
+	cstr := C.GetMagickFeatures()
+	return C.GoString(cstr)
 }
 
 // Returns the ImageMagick API copyright as a string constant.


### PR DESCRIPTION
ImageMagick provides a function to list all registered delegates and a second function to list built-in features. Both are very useful for applications to know the capabilities of ImageMagick and to verify an ImageMagick installation.

This Pull Request adds the function `GetDelegates()` which returns the output of `GetMagickDelegates()` and the function `GetFeatures()` which returns the output of `GetMagickFeatures()`.