### PR TITLE
QueryFontMetrics nil pointer panic fix

### DIFF
--- a/imagick/magick_wand.go
+++ b/imagick/magick_wand.go
@@ -132,6 +132,9 @@ func (mw *MagickWand) QueryFontMetrics(dw *DrawingWand, textLine string) *FontMe
 	if err := mw.GetLastError(); err != nil {
 		return nil
 	}
+	if cdoubles == nil {
+		return nil
+	}
 	runtime.KeepAlive(mw)
 	runtime.KeepAlive(dw)
 	defer relinquishMemory(unsafe.Pointer(cdoubles))
@@ -145,6 +148,9 @@ func (mw *MagickWand) QueryMultilineFontMetrics(dw *DrawingWand, textParagraph s
 	defer C.free(unsafe.Pointer(cstext))
 	cdoubles := C.MagickQueryMultilineFontMetrics(mw.mw, dw.dw, cstext)
 	if err := mw.GetLastError(); err != nil {
+		return nil
+	}
+	if cdoubles == nil {
 		return nil
 	}
 	runtime.KeepAlive(mw)


### PR DESCRIPTION
[gographics/imagick@760c816](https://github.com/gographics/imagick/commit/760c816161fdf75dca4427da55021f314f407965) (v3.5.3, [#309](https://github.com/gographics/imagick/issues/309)) added a `GetLastError()` check, but the C functions can return NULL *without* setting an error — e.g. when Freetype is not compiled in.

```go
cdoubles := C.MagickQueryFontMetrics(mw.mw, dw.dw, cstext)
if err := mw.GetLastError(); err != nil { // NULL + no error → passes through
    return nil
}
defer relinquishMemory(unsafe.Pointer(cdoubles))
doubles := sizedDoubleArrayToFloat64Slice(cdoubles, 13) // <- panic: nil deref
```

Same issue in `QueryMultilineFontMetrics`.

## Fix

Add an explicit nil check on `cdoubles` after the existing error check.